### PR TITLE
Use the 2015-miccai tagged Docker image.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,9 +5,9 @@ machine:
 dependencies:
   override:
     - docker info
-    - docker pull insighttoolkit/simpleitk-notebooks:latest
+    - docker pull insighttoolkit/simpleitk-notebooks:2015-miccai
 
 test:
   override:
     - cd ~/SimpleITKTutorialMICCAI2015 && python ./downloaddata.py ./Data ./Data/manifest.json
-    - docker run -v ~/SimpleITKTutorialMICCAI2015:/home/jovyan/notebooks insighttoolkit/simpleitk-notebooks:latest ./test.sh
+    - docker run -v ~/SimpleITKTutorialMICCAI2015:/home/jovyan/notebooks insighttoolkit/simpleitk-notebooks:2015-miccai ./test.sh

--- a/run.sh
+++ b/run.sh
@@ -4,4 +4,4 @@ docker run \
   --rm \
   -p 8888:8888 \
   -v $PWD:/home/jovyan/notebooks/ \
-  insighttoolkit/simpleitk-notebooks
+  insighttoolkit/simpleitk-notebooks:2015-miccai


### PR DESCRIPTION
Specific versions are necessary for reproducibility.

This also adds Python 2 support to the image.
